### PR TITLE
call to a test specific database

### DIFF
--- a/manifests/deployment-strapi-test.yml
+++ b/manifests/deployment-strapi-test.yml
@@ -23,7 +23,7 @@ spec:
             - name: "APP_NAME"
               value: "strapi-app"
             - name: "DATABASE_NAME"
-              value: "strapi"
+              value: "strapitest"
             - name: "DATABASE_PORT"
               value: "5432"
             - name: "DATABASE_SSL"


### PR DESCRIPTION
Updated manifest to pull from a separate test database.

Once approved and deployed, you'll need to go to the testing pod on 1337 and login in and init the new testing database with an admin account.