### PR TITLE
Added Strapi configuration to optionally use sqlite database locally.

### DIFF
--- a/docs/strapi_readme.md
+++ b/docs/strapi_readme.md
@@ -25,6 +25,10 @@ Once the packages are installed, you can build Strapi by running
 
     npm run build
 
+If you want to build Strapi to use a sqlite database for local development, build build Strapi with the NODE_ENV environment variable set to local. This can be done at the same time as the build using the following command:
+
+    cmd /V /C "set NODE_ENV=local&&npm run build"
+
 To start Strapi in development mode, run 
 
     npm run develop

--- a/strapi/app/.env.example
+++ b/strapi/app/.env.example
@@ -1,4 +1,4 @@
-HOST=0.0.0.0
+HOST=localhost
 PORT=1337
 PREVIEW_SITE=<preview_site>
 PRODUCTION_SITE=<production_site>

--- a/strapi/app/config/database.js
+++ b/strapi/app/config/database.js
@@ -6,25 +6,46 @@
 // export DATABASE_PASSWORD="{PASSWORD}}"
 // export DATABASE_SSL="true"
 
-module.exports = ({ env }) => ({
-  defaultConnection: 'default',
-  connections: {
-    default: {
-      connector: 'bookshelf',
-      settings: {
-        client: 'postgres',
-          host: env('DATABASE_HOST', 'localhost'),
-          port: env.int('DATABASE_PORT', 5432),
-          database: env('DATABASE_NAME', 'strapi'),
-          username: env('DATABASE_USERNAME', ''),
-          password: env('DATABASE_PASSWORD', ''),
-          schema: 'public',
-          ssl: env('DATABASE_SSL', 'true'),
+module.exports = ({ env }) => {
+  if(env('NODE_ENV') === 'local') {
+    return {
+      defaultConnection: 'default',
+      connections: {
+        default: {
+          connector: 'bookshelf',
+          settings: {
+            client:'sqlite',
+            filename: env('DATABASE_FILENAME', '.tmp/data.db'),
+          },
+          options: {
+            useNullAsDefault: true,
+          }
+        }
+      }
+    }
+  } else {
+    return {
+      defaultConnection: 'default',
+      connections: {
+        default: {
+          connector: 'bookshelf',
+          settings: {
+            client: 'postgres',
+              host: env('DATABASE_HOST', 'localhost'),
+              port: env.int('DATABASE_PORT', 5432),
+              database: env('DATABASE_NAME', 'strapi'),
+              username: env('DATABASE_USERNAME', ''),
+              password: env('DATABASE_PASSWORD', ''),
+              schema: 'public',
+              ssl: env('DATABASE_SSL', 'true'),
+            },
+          options: {},
         },
-      options: {},
-    },
-  },
-});
+      },
+    }
+  }
+
+};
 
 // Keeping this here for use with Mongo and docker-compose
 // module.exports = ({ env }) => ({


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Added optional sqlite database configuration for Strapi. Sqlite is used when NODE_ENV=local.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Strapi was run locally to test.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes